### PR TITLE
Made elasticsearch discoverable by graylog2

### DIFF
--- a/install_graylog2_preview_ubuntu.sh
+++ b/install_graylog2_preview_ubuntu.sh
@@ -61,6 +61,8 @@ ln -s graylog2-server-0.2*/ graylog2-server
 echo "Installing elasticsearch"
 dpkg -i elasticsearch-0.90.7.deb
 sed -i -e 's|# cluster.name: elasticsearch|cluster.name: graylog2|' /etc/elasticsearch/elasticsearch.yml
+sed -i -e 's|# discovery\.zen\.ping\.multicast\.enabled: false|discovery\.zen\.ping\.multicast\.enabled: false|' /etc/elasticsearch/elasticsearch.yml
+sed -i -e 's|# discovery\.zen\.ping\.unicast\.hosts: \[[^]]\+\]|discovery\.zen\.ping\.unicast\.hosts: \["192.168.1.203:9300"\]|' /etc/elasticsearch/elasticsearch.yml
 
 # Test elasticsearch
 # curl -XGET 'http://localhost:9200/_cluster/health?pretty=true'


### PR DESCRIPTION
There were no config changes to make elasticsearch discoverable by graylog and server could not start. Now it does
